### PR TITLE
Allow multiple attributes to be defined in single cattr/iattr call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,23 @@
 ### Added
 
 - Support for defining multiple attributes in a single call to `cattr` or `iattr`.
-    - Example: `cattr :foo, :bar, default: 1`
-    - Shared options apply to all attributes.
+  - Example: `cattr :foo, :bar, default: 1`
+  - Shared options apply to all attributes.
+- Adds `cattr_setter` and `iattr_setter` for defining setters on attributes, useful when defining multiple attributes since ambiguous blocks are not allow.
+  ```ruby
+  class Config
+    include Cattri
+  
+    cattr :a, :b               # new functionality, does not allow setter blocks.
+                               # creates writers as def a=(val); @a = val; end
+    
+    cattr_setter :a do |val|   # redefines a= as def a=(val); val.to_s.downcase.to_sym; end
+      val.to_s.downcase.to_sym
+    end
+  end
+  ```
 - Validation to prevent use of a block when defining multiple attributes.
-    - Raises `Cattri::AmbiguousBlockError` if `&block` is passed with more than one attribute.
+  - Raises `Cattri::AmbiguousBlockError` if `&block` is passed with more than one attribute.
 
 ## [0.1.1] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.1.2] - 2025-04-22
+
+### Added
+
+- Support for defining multiple attributes in a single call to `cattr` or `iattr`.
+    - Example: `cattr :foo, :bar, default: 1`
+    - Shared options apply to all attributes.
+- Validation to prevent use of a block when defining multiple attributes.
+    - Raises `Cattri::AmbiguousBlockError` if `&block` is passed with more than one attribute.
+
 ## [0.1.1] - 2025-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ end
 * **ActiveSupport** extends the API but still relies on mutable class variables and offers no visibility control.
 * **Dry‑configurable** is robust yet heavyweight when you only need a handful of attributes outside a full config object.
 
-Cattri sits in the sweet spot: **micro‑sized (~200 LOC)**, dependency‑free, and purpose‑built for attribute declaration.
+Cattri sits in the sweet spot: **micro‑sized (~300 LOC)**, dependency‑free, and purpose‑built for attribute declaration.
 
 ---
 

--- a/lib/cattri/attribute_definer.rb
+++ b/lib/cattri/attribute_definer.rb
@@ -92,6 +92,18 @@ module Cattri
         end
       end
 
+      # Defines, or redefines, a writer method (`foo=`) that sets and coerces a value via the attribute setter.
+      #
+      # @param attribute [Cattri::Attribute]
+      # @param context [Cattri::Context]
+      # @return [void]
+      def define_writer!(attribute, context)
+        context.define_method!(attribute, name: :"#{attribute.name}=") do |value|
+          coerced_value = attribute.setter.call(value)
+          instance_variable_set(attribute.ivar, coerced_value)
+        end
+      end
+
       private
 
       # Returns the memoized value for an attribute or computes it from the default.

--- a/lib/cattri/class_attributes.rb
+++ b/lib/cattri/class_attributes.rb
@@ -20,9 +20,20 @@ module Cattri
   # Class attributes are stored internally as `Cattri::Attribute` instances and
   # values are memoized using class-level instance variables.
   module ClassAttributes
-    # Defines a class-level attribute with optional default, coercion, and reader access.
+    # Defines one or more class-level attributes with optional default, coercion, and reader access.
     #
-    # @param name [Symbol] the attribute name
+    # This method supports defining multiple attributes at once, provided they share the same options.
+    # If a block is given, only one attribute may be defined to avoid ambiguity.
+    #
+    # @example Define multiple attributes with shared options
+    #   class_attribute :foo, :bar, default: 42
+    #
+    # @example Define a single attribute with a coercion block
+    #   class_attribute :path do |val|
+    #     Pathname(val)
+    #   end
+    #
+    # @param names [Array<Symbol | String>] the names of the attributes to define
     # @param options [Hash] additional attribute options
     # @option options [Object, Proc] :default the default value or lambda
     # @option options [Boolean] :readonly whether the attribute is read-only
@@ -32,31 +43,29 @@ module Cattri
     # @raise [Cattri::AttributeError] or its subclasses, including `Cattri::AttributeDefinedError` or
     #   `Cattri::AttributeDefinitionError` if defining the attribute fails (e.g., if the attribute is
     #    already defined or an error occurs while defining methods)
-    def class_attribute(name, **options, &block)
-      options[:access] ||= __cattri_visibility
-      attribute = Cattri::Attribute.new(name, :class, options, block)
+    # @return [void]
+    def class_attribute(*names, **options, &block)
+      raise Cattri::AmbiguousBlockError if names.size > 1 && block_given?
 
-      raise Cattri::AttributeDefinedError, attribute if class_attribute_defined?(attribute.name)
-
-      begin
-        __cattri_class_attributes[name] = attribute
-
-        Cattri::AttributeDefiner.define_callable_accessor(attribute, context)
-        Cattri::AttributeDefiner.define_instance_level_reader(attribute, context) if attribute[:instance_reader]
-      rescue StandardError => e
-        raise Cattri::AttributeDefinitionError.new(self, attribute, e)
-      end
+      names.each { |name| define_class_attribute(name, options, block) }
     end
 
     # Defines a read-only class attribute.
     #
     # Equivalent to calling `class_attribute(name, readonly: true, ...)`
     #
-    # @param name [Symbol]
-    # @param options [Hash]
+    # @param names [Array<Symbol | String>] the names of the attributes to define
+    # @param options [Hash] additional attribute options
+    # @option options [Object, Proc] :default the default value or lambda
+    # @option options [Boolean] :readonly whether the attribute is read-only
+    # @option options [Boolean] :instance_reader whether to define an instance-level reader (default: true)
+    # @option options [Symbol] :access visibility level (:public, :protected, :private)
+    # @raise [Cattri::AttributeError] or its subclasses, including `Cattri::AttributeDefinedError` or
+    #   `Cattri::AttributeDefinitionError` if defining the attribute fails (e.g., if the attribute is
+    #    already defined or an error occurs while defining methods)
     # @return [void]
-    def class_attribute_reader(name, **options)
-      class_attribute(name, readonly: true, **options)
+    def class_attribute_reader(*names, **options)
+      class_attribute(*names, **options, readonly: true)
     end
 
     # Returns a list of defined class attribute names.
@@ -115,6 +124,36 @@ module Cattri
     alias cattr_definition class_attribute_definition
 
     private
+
+    # Defines a single class-level attribute.
+    #
+    # This is the internal implementation used by {.class_attribute} and its aliases.
+    # It constructs a `Cattri::Attribute`, registers it, and defines the necessary
+    # class and instance methods.
+    #
+    # @param name [Symbol] the name of the attribute to define
+    # @param options [Hash] additional attribute options (e.g., :default, :readonly)
+    # @param block [Proc, nil] an optional setter block for coercion
+    #
+    # @raise [Cattri::AttributeDefinedError] if the attribute has already been defined
+    # @raise [Cattri::AttributeDefinitionError] if method definition fails
+    #
+    # @return [void]
+    def define_class_attribute(name, options, block)
+      options[:access] ||= __cattri_visibility
+      attribute = Cattri::Attribute.new(name, :class, options, block)
+
+      raise Cattri::AttributeDefinedError, attribute if class_attribute_defined?(attribute.name)
+
+      begin
+        __cattri_class_attributes[name] = attribute
+
+        Cattri::AttributeDefiner.define_callable_accessor(attribute, context)
+        Cattri::AttributeDefiner.define_instance_level_reader(attribute, context) if attribute[:instance_reader]
+      rescue StandardError => e
+        raise Cattri::AttributeDefinitionError.new(self, attribute, e)
+      end
+    end
 
     # Internal registry of defined class-level attributes.
     #

--- a/lib/cattri/error.rb
+++ b/lib/cattri/error.rb
@@ -30,9 +30,31 @@ module Cattri
   #   rescue Cattri::AttributeDefinedError => e
   #     puts e.message
   class AttributeDefinedError < Cattri::AttributeError
-    # @param attribute [Cattri::Attribute] the conflicting attribute
-    def initialize(attribute)
-      super("#{attribute.type.capitalize} attribute :#{attribute.name} has already been defined")
+    # @param type [Symbol, String] either :class or :instance
+    # @param name [Symbol, String] the name of the missing attribute
+    def initialize(type, name)
+      super("#{type.capitalize} attribute :#{name} has already been defined")
+    end
+  end
+
+  # Raised when attempting to access or modify an attribute that has not been defined.
+  #
+  # This applies to both class-level and instance-level attributes.
+  # It is typically raised when calling `.class_attribute_setter` or `.instance_attribute_setter`
+  # on a name that does not exist or lacks the expected method (e.g., writer).
+  #
+  # @example
+  #   raise Cattri::AttributeNotDefinedError.new(:class, :foo)
+  #   # => Class attribute :foo has not been defined
+  #
+  # @example
+  #   rescue Cattri::AttributeNotDefinedError => e
+  #     puts e.message
+  class AttributeNotDefinedError < Cattri::AttributeError
+    # @param type [Symbol, String] either :class or :instance
+    # @param name [Symbol, String] the name of the missing attribute
+    def initialize(type, name)
+      super("#{type.capitalize} attribute :#{name} has not been defined")
     end
   end
 

--- a/lib/cattri/error.rb
+++ b/lib/cattri/error.rb
@@ -63,10 +63,21 @@ module Cattri
   # @example
   #   raise Cattri::UnsupportedTypeError.new(:foo)
   #   # => Attribute type :foo is not supported
-  class UnsupportedTypeError < Error
+  class UnsupportedTypeError < Cattri::AttributeError
     # @param type [Symbol] the invalid type that triggered the error
     def initialize(type)
       super("Attribute type :#{type} is not supported")
+    end
+  end
+
+  # Raised when a block is provided when defining a group of attributes `cattr :attr_a, :attr_b do ... end`
+  #
+  # @example
+  #   raise Cattri::AmbiguousBlockError
+  #   # => Cannot define multiple attributes with a block
+  class AmbiguousBlockError < Cattri::AttributeError
+    def initialize
+      super("Cannot define multiple attributes with a block")
     end
   end
 end

--- a/lib/cattri/version.rb
+++ b/lib/cattri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cattri
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/cattri/class_attributes_spec.rb
+++ b/spec/cattri/class_attributes_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Cattri::ClassAttributes do
       expect(subject).to respond_to(:items)
     end
 
+    it "defines multiple readonly attributes at once" do
+      test_class.class_attribute :a, :b, default: "locked"
+
+      expect(subject.a).to eq("locked")
+      expect(subject.b).to eq("locked")
+    end
+
     it "defines a reader" do
       expect(subject.items).to eq([])
     end
@@ -83,6 +90,12 @@ RSpec.describe Cattri::ClassAttributes do
         test_class.cattr :bar, default: 10
       end.to raise_error(Cattri::AttributeDefinitionError, /Failed to define method :bar on/)
     end
+
+    it "raises AmbiguousBlockError when using a block with multiple attributes" do
+      expect do
+        test_class.class_attribute(:a, :b) { |v| v }
+      end.to raise_error(Cattri::AmbiguousBlockError, "Cannot define multiple attributes with a block")
+    end
   end
 
   describe ".class_attribute_reader / .cattr_reader" do
@@ -103,6 +116,15 @@ RSpec.describe Cattri::ClassAttributes do
 
       expect(subject.readonly).to eq("static")
       expect(subject).not_to have_received(:instance_variable_set).with(:@readonly, "readonly")
+    end
+
+    it "defines multiple readonly attributes at once" do
+      test_class.class_attribute_reader :a, :b, default: "locked"
+
+      expect(subject.a).to eq("locked")
+      expect(subject.b).to eq("locked")
+      expect(subject).not_to respond_to(:a=)
+      expect(subject).not_to respond_to(:b=)
     end
   end
 

--- a/spec/cattri/class_attributes_spec.rb
+++ b/spec/cattri/class_attributes_spec.rb
@@ -128,6 +128,41 @@ RSpec.describe Cattri::ClassAttributes do
     end
   end
 
+  describe ".class_attribute_setter / .cattr_setter" do
+    it "replaces the setter for an existing attribute" do
+      test_class.class_attribute_setter(:items) do |val|
+        puts "<<< #{val.inspect} >>>"
+        Array(val).map(&:to_sym)
+      end
+
+      subject.items = %w[a b c]
+
+      expect(subject.items).to eq(%i[a b c])
+    end
+
+    it "updates the callable form as well" do
+      test_class.class_attribute_setter(:items) do |*val|
+        Array(val).reverse
+      end
+
+      subject.items 1, 2, 3
+
+      expect(subject.items).to eq([3, 2, 1])
+    end
+
+    it "raises AttributeNotDefinedError if the attribute is not defined" do
+      expect do
+        test_class.class_attribute_setter(:undefined) { |v| v }
+      end.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :undefined has not been defined/)
+    end
+
+    it "raises AttributeNotDefinedError if the writer method does not exist" do
+      expect do
+        test_class.class_attribute_setter(:readonly) { |v| v }
+      end.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :readonly has not been defined/)
+    end
+  end
+
   describe ".class_attributes / .cattrs" do
     it "returns all defined class attributes" do
       expect(subject.class_attributes).to eq(%i[items map readonly no_instance_access normalized_symbol])

--- a/spec/cattri/error_spec.rb
+++ b/spec/cattri/error_spec.rb
@@ -11,9 +11,19 @@ RSpec.describe Cattri::Error do
     let(:attribute) { instance_double(Cattri::Attribute, name: :foo, type: :class) }
 
     it "raises an error when an attribute is defined more than once" do
-      error = Cattri::AttributeDefinedError.new(attribute)
+      error = Cattri::AttributeDefinedError.new(attribute.type, attribute.name)
 
       expect(error.message).to eq("Class attribute :foo has already been defined")
+    end
+  end
+
+  describe "Cattri::AttributeNotDefinedError" do
+    let(:attribute) { instance_double(Cattri::Attribute, name: :foo, type: :class) }
+
+    it "raises an error when an attribute has not yet been defined" do
+      error = Cattri::AttributeNotDefinedError.new(attribute.type, attribute.name)
+
+      expect(error.message).to eq("Class attribute :foo has not been defined")
     end
   end
 

--- a/spec/cattri/error_spec.rb
+++ b/spec/cattri/error_spec.rb
@@ -39,4 +39,12 @@ RSpec.describe Cattri::Error do
       expect(error.message).to eq("Attribute type :invalid_type is not supported")
     end
   end
+
+  describe "Cattri::AmbiguousBlockError" do
+    it "raises an error when an ambiguous block is passed" do
+      error = Cattri::AmbiguousBlockError.new
+
+      expect(error.message).to eq("Cannot define multiple attributes with a block")
+    end
+  end
 end

--- a/spec/cattri/instance_attributes_spec.rb
+++ b/spec/cattri/instance_attributes_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Cattri::InstanceAttributes do
       expect(instance).to respond_to(:items)
     end
 
+    it "defines multiple write-only attributes" do
+      test_class.instance_attribute :x, :y
+      instance = test_class.new
+
+      expect(instance).to respond_to(:x=)
+      expect(instance).to respond_to(:y=)
+      expect(instance).to respond_to(:x)
+      expect(instance).to respond_to(:y)
+    end
+
     it "defines a reader" do
       expect(instance.items).to eq([])
     end
@@ -56,6 +66,12 @@ RSpec.describe Cattri::InstanceAttributes do
         test_class.iattr :bar, default: 10
       end.to raise_error(Cattri::AttributeDefinitionError, /Failed to define method :bar on/)
     end
+
+    it "raises AmbiguousBlockError when using a block with multiple attributes" do
+      expect do
+        test_class.iattr(:foo, :bar) { |v| v }
+      end.to raise_error(Cattri::AmbiguousBlockError, "Cannot define multiple attributes with a block")
+    end
   end
 
   describe ".instance_attribute_reader / .iattr_reader" do
@@ -70,6 +86,15 @@ RSpec.describe Cattri::InstanceAttributes do
     it "does not allow setting a readonly attribute" do
       expect { instance.readonly = "fail" }.to raise_error(NoMethodError)
     end
+
+    it "defines multiple read-only attributes" do
+      test_class.iattr_reader :alpha, :beta, default: "readable"
+
+      expect(instance).to respond_to(:alpha)
+      expect(instance).to respond_to(:beta)
+      expect(instance).not_to respond_to(:alpha=)
+      expect(instance).not_to respond_to(:beta=)
+    end
   end
 
   describe ".instance_attribute_writer / .iattr_writer" do
@@ -83,6 +108,15 @@ RSpec.describe Cattri::InstanceAttributes do
 
     it "does not allow getting a write-only attribute" do
       expect { instance.secret }.to raise_error(NoMethodError)
+    end
+
+    it "defines multiple write-only attributes" do
+      test_class.iattr_writer :x, :y
+
+      expect(instance).to respond_to(:x=)
+      expect(instance).to respond_to(:y=)
+      expect(instance).not_to respond_to(:x)
+      expect(instance).not_to respond_to(:y)
     end
   end
 

--- a/spec/cattri/instance_attributes_spec.rb
+++ b/spec/cattri/instance_attributes_spec.rb
@@ -120,6 +120,29 @@ RSpec.describe Cattri::InstanceAttributes do
     end
   end
 
+  describe ".instance_attribute_setter / .iattr_setter" do
+    it "replaces the setter for an existing attribute" do
+      test_class.instance_attribute_setter(:items) do |val|
+        Array(val).map(&:to_sym)
+      end
+
+      instance.items = %w[a b c]
+      expect(instance.items).to eq(%i[a b c])
+    end
+
+    it "raises AttributeNotDefinedError if the attribute is not defined" do
+      expect do
+        test_class.instance_attribute_setter(:unknown) { |v| v }
+      end.to raise_error(Cattri::AttributeNotDefinedError, /Instance attribute :unknown has not been defined/)
+    end
+
+    it "raises AttributeDefinitionError if the attribute is readonly" do
+      expect do
+        test_class.instance_attribute_setter(:readonly) { |v| v }
+      end.to raise_error(Cattri::AttributeError, /Cannot define setter for readonly attribute :readonly/)
+    end
+  end
+
   describe ".instance_attributes / .iattrs" do
     it "returns all defined instance attributes" do
       expect(test_class.instance_attributes).to eq(%i[items readonly secret normalized_symbol])


### PR DESCRIPTION
Adds the ability to define multiple attributes at once.

```ruby
class Config
  include Cattri

  cattr :a, :b.                          # defines self.a/a=, self.b/b= defaulting to nil.
  cattr_reader :c, :d, default: false    # defines self.c, self.d readers, defaulting to false.

  cattr :e, :f do |val|                  # raises Cattri::AmbiguousBlockError, blocks not allow
    val                                  # for multiple attribute definitions.
  end
```

```ruby
class Config
  include Cattri

  iattr :a, :b                           # defines new.a/a=, new.b/b= defaulting to nil.
  iattr_reader :c, :d, default: false    # defines new.a, new.b readers, defaulting to false.
  iattr_writer :e, :f                    # defines new.a, new.b writers, setters are not allowed.

  iattr :e, :f do |val|                  # raises Cattri::AmbiguousBlockError, blocks not allow
    val                                  # for multiple attribute definitions.
  end
end
```

Due to multiple attribute definitions not allowing an ambiguous setter block to provided, this also introduces `class_attribute_setter/cattr_setter` and `instance_attribute_setter/iattr_setter`

```ruby
class Config
  include Cattri

  cattr :a, :b                          # defines def (a|b)=(v); @(a|b) = v; end

  cattr_setter :a do |val|              # applies a setter to the :a variable, changing it
    val.to_s.downcase.to_sym            # to def a=(v); @a = v.to_s.downcase.to_sym; end
  end