### PR TITLE
Add alias and predicate support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.1.3] - 2025-04-22
+
+### Added
+
+- ✅ Support for `predicate: true` on both `iattr` and `cattr` — defines a `:name?` method returning `!!send(:name)`
+- ✅ `iattr_alias` and `cattr_alias` — define alias methods that delegate to existing attributes (e.g., `:foo?` for `:foo`)
+- Predicate methods inherit visibility from the original attribute and are excluded from introspection (`iattrs`, `cattrs`)
+- Raised error when attempting to define an attribute ending in `?`, with guidance to use `predicate: true` or `*_alias`
+
 ## [0.1.2] - 2025-04-22
 
 ### Added

--- a/lib/cattri/attribute.rb
+++ b/lib/cattri/attribute.rb
@@ -23,13 +23,15 @@ module Cattri
     # Default options for class-level attributes.
     DEFAULT_CLASS_ATTRIBUTE_OPTIONS = {
       readonly: false,
-      instance_reader: true
+      instance_reader: true,
+      predicate: false
     }.freeze
 
     # Default options for instance-level attributes.
     DEFAULT_INSTANCE_ATTRIBUTE_OPTIONS = {
       reader: true,
-      writer: true
+      writer: true,
+      predicate: false
     }.freeze
 
     # @return [Symbol] the attribute name

--- a/lib/cattri/attribute_definer.rb
+++ b/lib/cattri/attribute_definer.rb
@@ -47,11 +47,30 @@ module Cattri
       def define_instance_level_reader(attribute, context)
         return unless attribute.class_level?
 
-        context.target.define_method(attribute.name) do
+        define_instance_level_method(attribute, context) do
           self.class.__send__(attribute.name)
         end
 
         context.send(:apply_access, attribute.name, attribute)
+      end
+
+      # Defines an instance-level method for a class-level attribute.
+      #
+      # This is a shared utility for defining instance methods that delegate to class attributes,
+      # including both regular readers and predicate-style readers (`predicate: true`).
+      #
+      # Visibility is inherited from the attribute and applied to the defined method.
+      #
+      # @param attribute [Cattri::Attribute] the associated attribute metadata
+      # @param context [Cattri::Context] the context in which to define the method
+      # @param name [Symbol, nil] optional override for the method name (defaults to `attribute.name`)
+      # @yield the method body to define
+      # @return [void]
+      def define_instance_level_method(attribute, context, name: nil, &block)
+        name = (name || attribute.name).to_sym
+        context.target.define_method(name, &block)
+
+        context.send(:apply_access, name, attribute)
       end
 
       # Defines standard reader and writer methods for instance-level attributes.

--- a/lib/cattri/version.rb
+++ b/lib/cattri/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Cattri
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/cattri/class_attributes_spec.rb
+++ b/spec/cattri/class_attributes_spec.rb
@@ -85,6 +85,21 @@ RSpec.describe Cattri::ClassAttributes do
       expect(subject.with_predicate?).to eq(false)
     end
 
+    it "defines an instance-level predicate proxy" do
+      subject.cattr :with_predicate, default: "123", predicate: true
+      instance = subject.new
+
+      expect(instance).to respond_to(:with_predicate?)
+      expect(instance.with_predicate?).to eq(true)
+    end
+
+    it "does not define an instance-level predicate proxy" do
+      subject.cattr :with_predicate, default: "123", predicate: true, instance_reader: false
+      instance = subject.new
+
+      expect(instance).not_to respond_to(:with_predicate?)
+    end
+
     it "raises an AttributeError when a predicate (ends_with?('?')) attribute is defined" do
       expect do
         test_class.cattr :predicate?, default: "123"

--- a/spec/cattri/class_attributes_spec.rb
+++ b/spec/cattri/class_attributes_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe Cattri::ClassAttributes do
       expect(instance).not_to respond_to(:no_instance_access)
     end
 
+    it "defines a predicate method" do
+      subject.cattr :with_predicate, default: "123", predicate: true
+
+      expect(subject).to respond_to(:with_predicate)
+      expect(subject).to respond_to(:with_predicate?)
+      expect(subject.with_predicate?).to eq(true)
+
+      subject.with_predicate = nil
+      expect(subject.with_predicate?).to eq(false)
+    end
+
+    it "raises an AttributeError when a predicate (ends_with?('?')) attribute is defined" do
+      expect do
+        test_class.cattr :predicate?, default: "123"
+      end.to raise_error(Cattri::AttributeError, /names ending in '\?' are not allowed/)
+    end
+
     it "raises an AttributeDefinedError if the attribute is already defined" do
       test_class.cattr :foo, default: 42
 
@@ -160,6 +177,23 @@ RSpec.describe Cattri::ClassAttributes do
       expect do
         test_class.class_attribute_setter(:readonly) { |v| v }
       end.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :readonly has not been defined/)
+    end
+  end
+
+  describe ".class_attribute_alias / .cattr_alias" do
+    it "defines an alias method" do
+      test_class.cattr :original, default: [1, 2, 3]
+      test_class.cattr_alias :original_alias, :original
+
+      expect(subject).to respond_to(:original)
+      expect(subject).to respond_to(:original_alias)
+      expect(subject.original_alias).to eq(subject.original)
+    end
+
+    it "raises AttributeNotDefinedError when the original method is not defined" do
+      expect {
+        test_class.cattr_alias :alias_method, :unknown
+      }.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :unknown has not been defined/)
     end
   end
 

--- a/spec/cattri/class_attributes_spec.rb
+++ b/spec/cattri/class_attributes_spec.rb
@@ -206,9 +206,9 @@ RSpec.describe Cattri::ClassAttributes do
     end
 
     it "raises AttributeNotDefinedError when the original method is not defined" do
-      expect {
+      expect do
         test_class.cattr_alias :alias_method, :unknown
-      }.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :unknown has not been defined/)
+      end.to raise_error(Cattri::AttributeNotDefinedError, /Class attribute :unknown has not been defined/)
     end
   end
 
@@ -278,6 +278,8 @@ RSpec.describe Cattri::ClassAttributes do
       %i[cattr class_attribute],
       %i[cattr_accessor class_attribute],
       %i[cattr_reader class_attribute_reader],
+      %i[cattr_setter class_attribute_setter],
+      %i[cattr_alias class_attribute_alias],
       %i[cattrs class_attributes],
       %i[cattr_defined? class_attribute_defined?],
       %i[cattr_definition class_attribute_definition]

--- a/spec/cattri/instance_attributes_spec.rb
+++ b/spec/cattri/instance_attributes_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe Cattri::InstanceAttributes do
     end
 
     it "raises AttributeNotDefinedError when the original method is not defined" do
-      expect {
+      expect do
         test_class.iattr_alias :alias_method, :unknown
-      }.to raise_error(Cattri::AttributeNotDefinedError, /Instance attribute :unknown has not been defined/)
+      end.to raise_error(Cattri::AttributeNotDefinedError, /Instance attribute :unknown has not been defined/)
     end
   end
 
@@ -224,6 +224,8 @@ RSpec.describe Cattri::InstanceAttributes do
       %i[iattr_accessor instance_attribute],
       %i[iattr_reader instance_attribute_reader],
       %i[iattr_writer instance_attribute_writer],
+      %i[iattr_setter instance_attribute_setter],
+      %i[iattr_alias instance_attribute_alias],
       %i[iattrs instance_attributes],
       %i[iattr_defined? instance_attribute_defined?],
       %i[iattr_definition instance_attribute_definition]

--- a/spec/cattri/instance_attributes_spec.rb
+++ b/spec/cattri/instance_attributes_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Cattri::InstanceAttributes do
       expect(instance.items).to eq([1, 2, 3])
     end
 
+    it "defines a predicate method" do
+      test_class.iattr :with_predicate, default: "123", predicate: true
+      instance = test_class.new
+
+      expect(instance).to respond_to(:with_predicate)
+      expect(instance).to respond_to(:with_predicate?)
+      expect(instance.with_predicate?).to eq(true)
+
+      instance.with_predicate = nil
+      expect(instance.with_predicate?).to eq(false)
+    end
+
+    it "raises an AttributeError when a predicate (ends_with?('?')) attribute is defined" do
+      expect do
+        test_class.iattr :predicate?, default: "123"
+      end.to raise_error(Cattri::AttributeError, /names ending in '\?' are not allowed/)
+    end
+
     it "raises an AttributeDefinedError if the attribute is already defined" do
       test_class.iattr :foo, default: 42
 
@@ -140,6 +158,24 @@ RSpec.describe Cattri::InstanceAttributes do
       expect do
         test_class.instance_attribute_setter(:readonly) { |v| v }
       end.to raise_error(Cattri::AttributeError, /Cannot define setter for readonly attribute :readonly/)
+    end
+  end
+
+  describe ".instance_attribute_alias / .iattr_alias" do
+    it "defines an alias method" do
+      test_class.iattr :original, default: [1, 2, 3]
+      test_class.iattr_alias :original_alias, :original
+      instance = test_class.new
+
+      expect(instance).to respond_to(:original)
+      expect(instance).to respond_to(:original_alias)
+      expect(instance.original_alias).to eq(instance.original)
+    end
+
+    it "raises AttributeNotDefinedError when the original method is not defined" do
+      expect {
+        test_class.iattr_alias :alias_method, :unknown
+      }.to raise_error(Cattri::AttributeNotDefinedError, /Instance attribute :unknown has not been defined/)
     end
   end
 


### PR DESCRIPTION
This adds attribute aliasing and predicate support to both class- and instance-level attributes.

### Alias Support
Defines an alias method that is not registered on the class context, just a simple proxy to the original method. An error is raised if the method you're trying to alias has not been defined.

```ruby
class Config
  cattr :enabled, default: true     # iattr :enabled, default: true
  cattr_alias :allowed, :enabled    # iattr_alias :allowed, :enabled

  cattr_alias :alias_attr, :unknown # raises Cattri::AttributeNotDefinedError

  # Config.allowed -> def allowed; send(:enabled); end
end
```

### Predicate support
The new `predicate: true|false` flag on `cattr ...` and `iattr ...` defines a proxy method of `#{name}?` that is not registered on the class context. This proxy calls `!!send(:name)`.

A guard was also added in so attributes cannot be defined as predicates directly, they must use the new flag on a regular attribute.

```ruby
class Config
  cattr :enabled?                                   # raises Cattri::AttributeError
  cattr :enabled, default: true, predicate: true    # iattr :enabled, default: true, predicate: true

  # Config.enabled? -> def enabled?; !!send(:enabled); end
end
```