### PR TITLE
0.2.1 - fixed ancestor walking on final instance attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [0.2.1] - 2025-05-01
+
+- Fixed an issue where only `final: true` instance variables defined on the current/class had their values applied.
+  - Now walks the ancestor tree to ensure all attributes get set.
+
+  ```ruby
+  module Options
+    include Cattri
+
+    cattri :enabled, true, final: true # wasn't being set previously
+  end
+
+  class Attribute
+    include Options
+  
+    def initialize(enabled: true)
+      seld.enabled = enabled
+    end
+  end
+  ```
+- Cleanup of `cattri.gemspec` and `bin/console`.
+
 ## [0.2.0] - 2025-05-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ class User
   cattri :id, -> { SecureRandom.uuid }, final: true
 
   # Writable instance-level attributes
-  cattri :name, "anonymous"
+  cattri :name, "anonymous" do |value|
+    value.to_s.capitalize # custom setter/coercer
+  end
+
   cattri :admin, false, predicate: true
 
   def initialize(id)

--- a/bin/console
+++ b/bin/console
@@ -4,30 +4,5 @@
 require "bundler/setup"
 require "cattri"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# class Tester
-#   include Cattri
-#
-#   cattr :public_attr, default: 1
-#
-#   protected
-#   cattr :protected_attr, default: 2
-#
-#   private
-#   cattr :private_attr, default: 3
-#
-#   class << self
-#     def protected_proxy
-#       self.protected_attr
-#     end
-#
-#     def private_proxy
-#       self.private_attr
-#     end
-#   end
-# end
-
 require "irb"
 IRB.start(__FILE__)

--- a/cattri.gemspec
+++ b/cattri.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir.chdir(__dir__) do
-    (`git ls-files -z`.split("\x0") + %w[README.md LICENSE]).uniq
+    (`git ls-files -z`.split("\x0") + %w[README.md LICENSE.txt]).uniq
   end
 
   # Runtime dependencies

--- a/lib/cattri/initializer_patch.rb
+++ b/lib/cattri/initializer_patch.rb
@@ -26,7 +26,8 @@ module Cattri
     def initialize(*args, **kwargs, &block)
       super
 
-      self.class.send(:attribute_registry).registered_attributes.each_value do |attribute| # steep:ignore
+      registry = self.class.send(:attribute_registry)
+      registry.defined_attributes(with_ancestors: true).each_value do |attribute| # steep:ignore
         next if cattri_variable_defined?(attribute.ivar) # steep:ignore
         next unless attribute.final?
 

--- a/lib/cattri/version.rb
+++ b/lib/cattri/version.rb
@@ -2,6 +2,6 @@
 
 module Cattri
   # :nocov:
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
   # :nocov:
 end

--- a/sig/lib/cattri/attribute.rbs
+++ b/sig/lib/cattri/attribute.rbs
@@ -27,7 +27,17 @@ module Cattri
     # @param options [Hash] configuration options
     # @option options [Boolean] :class whether the attribute is class-level (internally mapped to :class_attribute)
     # @param transformer [Proc] optional block used to coerce/validate assigned values
-    def initialize: (identifier name, defined_in: ::Module, **attribute_options options) { (?) -> untyped } -> void
+    def initialize: (
+        identifier name,
+        defined_in: ::Module,
+        ?ivar: identifier,
+        ?final: bool,
+        ?scope: scope_types,
+        ?predicate: bool,
+        ?default: ::Proc | untyped | nil,
+        ?expose: expose_types,
+        ?visibility: visibility_types
+      ) { (?) -> untyped } -> void
 
     # Serializes this attribute and its configuration to a frozen hash.
     #

--- a/sig/lib/cattri/attribute_registry.rbs
+++ b/sig/lib/cattri/attribute_registry.rbs
@@ -55,7 +55,13 @@ module Cattri
     def define_attribute: (
         identifier name,
         Proc | untyped value,
-        **attribute_options options
+        ?ivar: identifier,
+        ?final: bool,
+        ?scope: scope_types,
+        ?predicate: bool,
+        ?default: ::Proc | untyped | nil,
+        ?expose: expose_types,
+        ?visibility: visibility_types
       ) { (?) -> untyped } -> ::Array[::Symbol]
 
     # Copies registered attributes from this context to another,

--- a/sig/lib/cattri/dsl.rbs
+++ b/sig/lib/cattri/dsl.rbs
@@ -28,7 +28,13 @@ module Cattri
     def cattri: (
         identifier? name,
         ?untyped? value,
-        **attribute_options options
+        ?ivar: identifier,
+        ?final: bool,
+        ?scope: scope_types,
+        ?predicate: bool,
+        ?default: ::Proc | untyped | nil,
+        ?expose: expose_types,
+        ?visibility: visibility_types
       ) { (?) -> untyped } -> ::Array[::Symbol]
 
     # Defines a write-once (final) attribute.
@@ -49,7 +55,12 @@ module Cattri
     def final_cattri: (
         identifier name,
         untyped value,
-        **attribute_options options
+        ?ivar: identifier,
+        ?scope: scope_types,
+        ?predicate: bool,
+        ?default: ::Proc | untyped | nil,
+        ?expose: expose_types,
+        ?visibility: visibility_types
       ) { (?) -> untyped } -> ::Array[::Symbol]
   end
 end

--- a/sig/lib/cattri/types.rbs
+++ b/sig/lib/cattri/types.rbs
@@ -6,14 +6,4 @@ module Cattri
   type expose_types = :read_write | :read | :write | :none
 
   type visibility_types = :public | :protected | :private
-
-  type attribute_options = {
-      ivar?: identifier,
-      final: bool,
-      scope?: scope_types,
-      predicate?: bool,
-      default?: ::Proc | untyped,
-      expose?: expose_types,
-      visibility?: visibility_types
-    }
 end


### PR DESCRIPTION
- Fixed an issue where only `final: true` instance variables defined on the current/class had their values applied.
  - Now walks the ancestor tree to ensure all attributes get set.

  ```ruby
  module Options
    include Cattri

    cattri :enabled, true, final: true # wasn't being set previously
  end

  class Attribute
    include Options
  
    def initialize(enabled: true)
      seld.enabled = enabled
    end
  end
  ```
- Cleanup of `cattri.gemspec` and `bin/console`.