### PR TITLE
CATTRI-1: Fixed expose: :read preventing internal writes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
         ruby:
           - '2.7.0'
           - '3.1.4'
+          - '3.2.9'
+          - '3.3.10'
+          - '3.4.7'
 
     steps:
       - uses: actions/checkout@v4

--- a/lib/cattri/attribute.rb
+++ b/lib/cattri/attribute.rb
@@ -94,11 +94,11 @@ module Cattri
       %i[read read_write].include?(@options.expose)
     end
 
-    # @return [Boolean] whether the attribute allows writing
+    # @return [Boolean] whether the attribute should define a writer (public or internal)
     def writable?
       return false if @options.expose == :none
 
-      !readonly?
+      !readonly? || internal_writer?
     end
 
     # @return [Boolean] whether the attribute is marked readonly

--- a/lib/cattri/version.rb
+++ b/lib/cattri/version.rb
@@ -2,6 +2,6 @@
 
 module Cattri
   # :nocov:
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
   # :nocov:
 end

--- a/sig/lib/cattri/dsl.rbs
+++ b/sig/lib/cattri/dsl.rbs
@@ -35,7 +35,7 @@ module Cattri
         ?default: ::Proc | untyped | nil,
         ?expose: expose_types,
         ?visibility: visibility_types
-      ) { (?) -> untyped } -> ::Array[::Symbol]
+      ) ?{ (?) -> untyped } -> ::Array[::Symbol]
 
     # Defines a write-once (final) attribute.
     #
@@ -61,6 +61,6 @@ module Cattri
         ?default: ::Proc | untyped | nil,
         ?expose: expose_types,
         ?visibility: visibility_types
-      ) { (?) -> untyped } -> ::Array[::Symbol]
+      ) ?{ (?) -> untyped } -> ::Array[::Symbol]
   end
 end

--- a/spec/cattri/attribute_compiler_spec.rb
+++ b/spec/cattri/attribute_compiler_spec.rb
@@ -78,13 +78,37 @@ RSpec.describe Cattri::AttributeCompiler do
         )
       end
 
-      it "does not define a writer" do
+      it "keeps the writer private" do
         described_class.define_accessor(attribute, context)
         instance = dummy_class.new
 
         expect(instance.visible).to eq("shown")
         expect(instance.respond_to?(:visible=)).to be(false)
-        expect(instance.respond_to?(:visible=, true)).to be(false)
+        expect(instance.respond_to?(:visible=, true)).to be(true)
+
+        instance.send(:visible=, "hidden")
+        expect(instance.visible).to eq("hidden")
+      end
+    end
+
+    context "when writable? returns false" do
+      let(:attribute) do
+        Cattri::Attribute.new(
+          :disabled_writer,
+          defined_in: dummy_class,
+          default: -> { "initial" },
+          expose: :read_write
+        )
+      end
+
+      it "skips writer definition" do
+        allow(attribute).to receive(:writable?).and_return(false)
+
+        described_class.define_accessor(attribute, context)
+        instance = dummy_class.new
+
+        expect(instance).not_to respond_to(:disabled_writer=)
+        expect(instance.disabled_writer).to eq("initial")
       end
     end
   end

--- a/spec/cattri/attribute_spec.rb
+++ b/spec/cattri/attribute_spec.rb
@@ -111,11 +111,11 @@ RSpec.describe Cattri::Attribute do
 
   describe "#writable?" do
     [
-      [true, :read, false],
+      [true, :read, true],
       [true, :write, true],
       [true, :read_write, true],
       [true, :none, false],
-      [false, :read, false],
+      [false, :read, true],
       [false, :write, true],
       [false, :read_write, true],
       [false, :none, false]
@@ -190,20 +190,26 @@ RSpec.describe Cattri::Attribute do
   end
 
   describe "#allowed_methods" do
-    shared_examples_for "allowed method set" do |writable, predicate, expected|
-      let(:expose) { writable ? :read_write : :read }
-      let(:predicate) { predicate }
-      let(:final) { false }
+    [
+      [:read_write, true,  %i[attr attr= attr?]],
+      [:read_write, false, %i[attr attr=]],
+      [:read, true,        %i[attr attr= attr?]],
+      [:read, false,       %i[attr attr=]],
+      [:write, true,       %i[attr attr= attr?]],
+      [:write, false,      %i[attr attr=]],
+      [:none, true,        %i[attr attr?]],
+      [:none, false,       [:attr]]
+    ].each do |(exposure, predicate_value, expected)|
+      context "when expose is #{exposure} and predicate: #{predicate_value}" do
+        let(:expose) { exposure }
+        let(:predicate) { predicate_value }
+        let(:final) { false }
 
-      it "returns #{expected.inspect} for writable: #{writable}, predicate: #{predicate}" do
-        expect(attribute.allowed_methods).to eq(expected)
+        it "returns #{expected.inspect}" do
+          expect(attribute.allowed_methods).to eq(expected)
+        end
       end
     end
-
-    it_behaves_like "allowed method set", true,  true,  %i[attr attr= attr?]
-    it_behaves_like "allowed method set", true,  false, %i[attr attr=]
-    it_behaves_like "allowed method set", false, true,  %i[attr attr?]
-    it_behaves_like "allowed method set", false, false, [:attr]
   end
 
   describe "#validate_assignment!" do

--- a/spec/cattri_spec.rb
+++ b/spec/cattri_spec.rb
@@ -206,6 +206,23 @@ RSpec.describe Cattri do
       expect(obj.token).to eq("abc123")
       expect { obj.token = "fail" }.to raise_error(Cattri::AttributeError)
     end
+
+    it "allows internal assignment for read-exposed attributes" do
+      klass = Class.new do
+        include Cattri
+
+        cattri :token, expose: :read
+
+        def initialize(token)
+          send(:token=, token)
+        end
+      end
+
+      instance = klass.new("abc123")
+
+      expect(instance.token).to eq("abc123")
+      expect { instance.token = "fail" }.to raise_error(NoMethodError)
+    end
   end
 
   describe "visibility with write-only exposure" do


### PR DESCRIPTION
- Added regression for `expose: :read` internal assignment (`spec/cattri_spec.rb`).
- Adjusted writer logic to generate internal writers for read-only exposure (`lib/cattri/attribute.rb`) and updated allowed method expectations (`spec/cattri/attribute_spec.rb`).
- Added coverage for skipped writer branch by stubbing writable? to false in the compiler spec (`spec/cattri/attribute_compiler_spec.rb`).
- Ensured read-only writers remain private but callable internally and updated predicate/allowed methods grids accordingly.